### PR TITLE
Update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ then log out.
 
 ```php
 // logout only if login was successful
-if ($loginResult) {
+if ($loginSuccess) {
     $api->logoutUser($accessToken);
 }
 ```


### PR DESCRIPTION
Suggesting a tiny change to the Readme...  The login success variable in the login example code is $loginSuccess while the logout example uses $loginResult.  Proposing changing the logout example to $loginSuccess for consistency.
