### PR TITLE
authenticateUser dumps password to output

### DIFF
--- a/lib/ApiClient.php
+++ b/lib/ApiClient.php
@@ -207,13 +207,11 @@ class ApiClient
             } else {
                 $url = ($url . '?' . http_build_query($queryParams)); 
             }
-            echo($url);
         }
 
         if ($this->config->getAllowEncoding()) {
             curl_setopt($curl, CURLOPT_ENCODING, '');
         }
-        print_r( $postData);
         if ($method === self::$POST) {
             curl_setopt($curl, CURLOPT_POST, true);
             curl_setopt($curl, CURLOPT_POSTFIELDS, $postData);


### PR DESCRIPTION
When calling AuthenticationApi::authenticateUser() the data being posted to the API (which contains the username and password) is dumped to the script output. If the client happens to be called in-process from a web page then the API username and password gets dumped to the visitors page which can then be used to compromise the user's exavault account.

Check ApiClient.php line 218, recommend removing the "print_r()".

Also line 212 in the same file. I'm not sure that 'echo' needs to be there either.