### PR TITLE
Fix direct_file swagger type for ResourceProperty class

### DIFF
--- a/lib/Model/ResourceProperty.php
+++ b/lib/Model/ResourceProperty.php
@@ -66,7 +66,7 @@ class ResourceProperty implements ArrayAccess
         'notification_settings' => 'string',
         'size' => 'int',
         'previewable' => 'bool',
-        'direct_file' => 'string',
+        'direct_file' => '\ExaVault\Sdk\Model\DirectFile[]',
         'type' => 'string'
     ];
 


### PR DESCRIPTION
This PR related to the issue with getResourceList - "Array to string conversion" while tried to serialise object from ExaVault API